### PR TITLE
add movie detail models

### DIFF
--- a/src/models/movie_details.py
+++ b/src/models/movie_details.py
@@ -1,0 +1,32 @@
+from typing import List, Optional
+from pydantic import BaseModel, Field
+
+
+class SearchResult(BaseModel):
+    title: str = Field(..., alias="Title")
+    year: str = Field(..., alias="Year")
+    id: str = Field(..., alias="imdbID")
+    type: str = Field(..., alias="Type")
+    poster: Optional[str] = Field(None, alias="Poster")
+
+
+class SearchData(BaseModel):
+    search_results: List[SearchResult] = Field(..., alias="Search")
+    total_results: str = Field(..., alias="totalResults")
+    response: str = Field(..., alias="Response")
+
+
+class MovieDetails(BaseModel):
+    id: str = Field(..., alias="imdbID")
+    title: str = Field(..., alias="Title")
+    year: str = Field(..., alias="Year")
+    type: str = Field(..., alias="Type")
+
+    runtime: Optional[str] = Field(None, alias="Runtime")
+    genre: Optional[str] = Field(None, alias="Genre")
+    actors: Optional[str] = Field(None, alias="Actors")
+    plot: Optional[str] = Field(None, alias="Plot")
+    country: Optional[str] = Field(None, alias="Country")
+    poster: Optional[str] = Field(None, alias="Poster")
+    imdb_rating: Optional[str] = Field(None, alias="imdbRating")
+    total_seasons: Optional[str] = Field(None, alias="totalSeasons")


### PR DESCRIPTION

# Pull Request

## 📝 Description

Adds core Pydantic models for **Cinemix API integration with OMDb**:

* `SearchResult` and `SearchData` for search responses
* `MovieDetails` for detailed responses

All models use **field aliases** to map OMDb’s raw fields (e.g., `Title`, `imdbID`) to our internal DTOs (`title`, `id`, etc.), ensuring consistency with our documented API contract.

## 🔗 Related Issues

* Closes #17 

## 🚀 Type of Change

* [x] ✨ New feature

## ✅ Checklist

* [x] Code follows project style guidelines
* [x] Field aliases match OMDb schema
* [x] API contract consistency verified
