### PR TITLE
fix: mismatch data in cache

### DIFF
--- a/src/services/cache_service.py
+++ b/src/services/cache_service.py
@@ -13,7 +13,7 @@ class CacheService:
         """
         await redis_client.client.set(
             f"movie_{movie_id}",
-            json.dumps(movie_obj.model_dump()),
+            json.dumps(movie_obj.model_dump(by_alias=True)),
             ex=settings.CACHE_TTL,
         )
 

--- a/src/utils/get_movie.py
+++ b/src/utils/get_movie.py
@@ -17,5 +17,5 @@ async def get_movie(movie_id: str):
             f"Cache hit for endpoint: {Endpoint.MOVIE_DETAILS}, movie id: {movie_id}"
         )
     return response_parser.parse_response(
-        cache.model_dump(), 200, Endpoint.MOVIE_DETAILS
+        cache.model_dump(by_alias=True), 200, Endpoint.MOVIE_DETAILS
     )


### PR DESCRIPTION
Fixed the validation errors from the retrieval of cache data

# Pull Request

## What’s Changed

adds `by_alias=True` parameter to the ,model_dump() method in:
- `cache_service.py` line `16`
```
await redis_client.client.set(
            f"movie_{movie_id}",
            json.dumps(movie_obj.model_dump(by_alias=True)),
            ex=settings.CACHE_TTL,
        )
```
- `get_movie.py` line `20`
```
return response_parser.parse_response(
        cache.model_dump(by_alias=True), 200, Endpoint.MOVIE_DETAILS
    )
```


## Why

fixes the validation error on the movie data retrieved from the cache

- the data which was store before the fix was:
 ```
 {
    "id": "some id",
    "title": "some title"
 }
 ```
 but the code expects the data to have:
 ```
  {
    "ImdbID": "some id",
    "Title": "some title"
 }
 ```

## Notes for Reviewers

wait for the cache data to expire or delete all cache data from the db manually

## Checklist

- [x] Tests pass locally
- [x] No debug code left in
- [x] Docs updated (if needed)
